### PR TITLE
fix: No custom attributes for script without src attribute

### DIFF
--- a/theming.module
+++ b/theming.module
@@ -50,8 +50,10 @@ function theming_pre_render_scripts(array $elements) {
       continue;
     }
     $attributes = &$processed_elements['scripts'][$index]['#attributes'];
-    $custom_attributes = $elements['#items'][$attributes['src']]['attributes'] ?? [];
-    $attributes = $custom_attributes + $attributes;
+    if ($src = $attributes['src'] ?? NULL) {
+      $custom_attributes = $elements['#items'][$src]['attributes'] ?? [];
+      $attributes = $custom_attributes + $attributes;
+    }
   }
   return $processed_elements;
 }


### PR DESCRIPTION
This commit simply excludes all script tags without a `src` attribute from this feature.

In order to include it we would need to reverse-engineer the index assignments done, in `drupal_pre_render_scripts()`. It might be easier to just copy and paste the function then instead.